### PR TITLE
🔒 fix command injection vulnerability in validate.ts

### DIFF
--- a/scripts/validate.ts
+++ b/scripts/validate.ts
@@ -82,7 +82,21 @@ for (const step of steps) {
   console.log(yellow(`\n> ${step.name}`));
   console.log(yellow(`> ${step.cmd}\n`));
 
-  const result = spawnSync(step.cmd, { stdio: 'inherit', shell: true });
+  const [command, ...args] = step.cmd.split(' ').filter(Boolean);
+
+  // Convert nx -> npx nx so Windows/UNIX consistently finds the bin
+  // without relying on shell:true or cross-spawn
+  let actualCmd = command;
+  let actualArgs = args;
+  if (command === 'nx') {
+    actualCmd = 'npx';
+    actualArgs = ['nx', ...args];
+  } else if (command === 'bun') {
+    // Bun binary should already be on path or local, but we pass it explicitly
+    // just using actualCmd = 'bun' is fine
+  }
+
+  const result = spawnSync(actualCmd, actualArgs, { stdio: 'inherit', shell: false });
 
   if (result.error) {
     console.error(red(`\nFailed to run: ${step.cmd}`));

--- a/scripts/validate.ts
+++ b/scripts/validate.ts
@@ -91,9 +91,6 @@ for (const step of steps) {
   if (command === 'nx') {
     actualCmd = 'npx';
     actualArgs = ['nx', ...args];
-  } else if (command === 'bun') {
-    // Bun binary should already be on path or local, but we pass it explicitly
-    // just using actualCmd = 'bun' is fine
   }
 
   const result = spawnSync(actualCmd, actualArgs, { stdio: 'inherit', shell: false });


### PR DESCRIPTION
🎯 **What:** The `spawnSync` command in `scripts/validate.ts` used `shell: true` with dynamic command strings derived from an array.
⚠️ **Risk:** Although the inputs to `spawnSync` here are currently hardcoded values from an array, this pattern is a classic vector for command injection. If this array were ever populated from an untrusted source, or if arguments were concatenated dynamically (e.g., from environment variables or input parameters), it would allow arbitrary shell execution by an attacker.
🛡️ **Solution:** Modified the code to use `shell: false`. Separated the command and its arguments using split. To maintain compatibility and binary resolution (particularly for `nx`), specific logic for running `npx nx` explicitly replaces the base command of `nx`. This ensures executions remain cross-platform compatible without relying on the shell or cross-spawn.

---
*PR created automatically by Jules for task [15374893660153226129](https://jules.google.com/task/15374893660153226129) started by @eng618*